### PR TITLE
[Feature] API 응답 통일, 예외 처리 코드 구현 

### DIFF
--- a/src/main/java/com/on/server/domain/chat/application/ChatService.java
+++ b/src/main/java/com/on/server/domain/chat/application/ChatService.java
@@ -1,0 +1,17 @@
+package com.on.server.domain.chat.application;
+
+import com.on.server.global.common.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    // ** 추후 삭제 예정 **
+    public String getApiTest() throws CustomException {
+        return "API 응답 통일 테스트입니다.";
+    }
+    // ******************
+
+}

--- a/src/main/java/com/on/server/domain/chat/presentation/ChatController.java
+++ b/src/main/java/com/on/server/domain/chat/presentation/ChatController.java
@@ -1,0 +1,29 @@
+package com.on.server.domain.chat.presentation;
+
+import com.on.server.domain.chat.application.ChatService;
+import com.on.server.global.common.CommonResponse;
+import com.on.server.global.common.CustomException;
+import com.on.server.global.common.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chat")
+public class ChatController {
+
+    private final ChatService chatService;
+
+    // ** 추후 삭제 예정 **
+    @GetMapping("/test")
+    public CommonResponse<?> apiTest() {
+        try {
+            return new CommonResponse<>(ResponseCode.SUCCESS, chatService.getApiTest());
+        } catch (CustomException e) {
+            return new CommonResponse<>(e.getStatus());
+        }
+    }
+    // ******************
+}

--- a/src/main/java/com/on/server/global/common/CommonResponse.java
+++ b/src/main/java/com/on/server/global/common/CommonResponse.java
@@ -1,0 +1,35 @@
+package com.on.server.global.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CommonResponse<T> {
+
+    private int code;
+    private boolean inSuccess;
+    private String message;
+    private T result;
+
+    // 요청에 성공한 경우
+    @Builder
+    public CommonResponse(ResponseCode status, T result) {
+        this.code = status.getCode();
+        this.inSuccess = status.isInSuccess();
+        this.message = status.getMessage();
+
+        this.result = result;
+    }
+
+    // 요청에 실패한 경우
+    @Builder
+    public CommonResponse(ResponseCode status) {
+        this.code = status.getCode();
+        this.inSuccess = status.isInSuccess();
+        this.message = status.getMessage();
+    }
+
+}

--- a/src/main/java/com/on/server/global/common/CustomException.java
+++ b/src/main/java/com/on/server/global/common/CustomException.java
@@ -1,0 +1,12 @@
+package com.on.server.global.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class CustomException extends Exception {
+    public ResponseCode status;
+}

--- a/src/main/java/com/on/server/global/common/ResponseCode.java
+++ b/src/main/java/com/on/server/global/common/ResponseCode.java
@@ -1,0 +1,44 @@
+package com.on.server.global.common;
+
+import lombok.Getter;
+
+@Getter
+public enum ResponseCode {
+    /*
+    1000 : Request 성공
+    */
+    SUCCESS(1000, true, "요청에 성공하였습니다."),
+
+    /*
+        2000~ : Request 오류
+    */
+
+
+    // =====================================
+    /*
+        3000~ : Response 오류
+    */
+
+    // 그 외 오류
+    INTERNAL_SERVER_ERROR(9000, false, "서버 오류가 발생했습니다.");
+
+
+    // =====================================
+    private int code;
+    private boolean inSuccess;
+    private String message;
+
+
+    /*
+        해당되는 코드 매핑
+        @param code
+        @param inSuccess
+        @param message
+
+     */
+    ResponseCode(int code, boolean inSuccess, String message) {
+        this.inSuccess = inSuccess;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/on/server/global/common/ResponseDto.java
+++ b/src/main/java/com/on/server/global/common/ResponseDto.java
@@ -1,0 +1,36 @@
+package com.on.server.global.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class ResponseDto<T> {
+    private int code;
+    private boolean inSuccess;
+    private String message;
+    private T result;
+
+    public ResponseDto(int code, boolean inSuccess, String message) {
+        this.code = code;
+        this.inSuccess = inSuccess;
+        this.message = message;
+        this.result = null;
+    }
+
+    public static <T> ResponseDto<T> response(int code, boolean inSuccess, String message) {
+        return response(code, inSuccess, message, null);
+    }
+
+
+    public static <T> ResponseDto<T> response(int code, boolean inSuccess, String message, T t) {
+        return ResponseDto.<T>builder()
+                .code(code)
+                .inSuccess(inSuccess)
+                .message(message)
+                .result(t)
+                .build();
+    }
+}


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> #4 

## 📝 작업 내용

> API 응답 통일 & 예외 처리 코드 추가

<img width="909" alt="스크린샷 2024-08-04 오전 3 59 30" src="https://github.com/user-attachments/assets/e0b0fbd2-85e5-4b44-982c-cc47deb18033">


> - `ChatService` 와 `ChatController` 참고하시면 됩니다! 참고용으로 작성한 코드(test)는 나중에 지우도록 하겠습니다.
> - 현재 `GET /chat/test`로 요청 보내면 카카오 로그인으로 리다이렉트 되는데, 테스트 코드는 다른 프로젝트에서 정상 작동되는 거 확인했습니다 :)
> 
