### PR TITLE
feat: postResponseDTO 변수명 및 구조 변경

### DIFF
--- a/src/main/java/com/on/server/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/on/server/domain/post/domain/repository/PostRepository.java
@@ -19,8 +19,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> searchPosts(@Param("keyword") String keyword);
 
     // 제목 또는 내용에 국가 이름이 포함된 게시글 검색
-    @Query("SELECT p FROM Post p WHERE p.title LIKE %:country% OR p.content LIKE %:country%")
-    List<Post> findByCountryInTitleOrContent(@Param("country") String country);
+    @Query("SELECT p FROM Post p WHERE p.board = :board AND (p.title LIKE %:country% OR p.content LIKE %:country%)")
+    List<Post> findByBoardAndCountryInTitleOrContent(@Param("board") Board board, @Param("country") String country);
 
     // 특정 게시판에서 최신 게시글 4개 조회
     List<Post> findTop4ByBoardOrderByCreatedAtDesc(Board board);

--- a/src/main/java/com/on/server/domain/post/dto/PostRequestDTO.java
+++ b/src/main/java/com/on/server/domain/post/dto/PostRequestDTO.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class PostRequestDTO {
 
     // 작성자 ID
-    private Long userId;
+    private Long id;
 
     // 게시글 제목
     private String title;

--- a/src/main/java/com/on/server/domain/post/dto/PostResponseDTO.java
+++ b/src/main/java/com/on/server/domain/post/dto/PostResponseDTO.java
@@ -1,6 +1,7 @@
 package com.on.server.domain.post.dto;
 
 import com.on.server.domain.board.domain.BoardType;
+import com.on.server.domain.user.domain.UserStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,20 +22,11 @@ public class PostResponseDTO {
     // 게시글 ID
     private Long postId;
 
-    // 작성자 ID
-    private Long userId;
-
-    // 작성자 닉네임
-    private String userNickname;
+    // 작성자 정보
+    private WriterInfo writerInfo;
 
     // 익명 여부
     private boolean isAnonymous;
-
-    // 파견국가
-    private String country;
-
-    // 파견교
-    private String dispatchedUniversity;
 
     // 파견교 공개 여부
     private boolean isAnonymousUniv;
@@ -53,4 +45,25 @@ public class PostResponseDTO {
 
     // 댓글 개수
     private Integer commentCount;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class WriterInfo {
+        // 작성자 ID
+        private Long id;
+
+        // 작성자 닉네임
+        private String nickname;
+
+        // 파견국가
+        private String country;
+
+        // 파견교
+        private String dispatchedUniversity;
+
+        // 작성자 상태
+        private UserStatus userStatus;
+    }
 }

--- a/src/main/java/com/on/server/domain/post/presentation/PostController.java
+++ b/src/main/java/com/on/server/domain/post/presentation/PostController.java
@@ -50,7 +50,7 @@ public class PostController {
         // 현재 인증된 사용자의 ID를 DTO에 설정
         if (userDetails instanceof User) {
             User user = (User) userDetails;
-            requestDTO.setUserId(user.getId());
+            requestDTO.setId(user.getId());
         }
 
         PostResponseDTO createdPost = postService.createPost(boardType, requestDTO);
@@ -92,11 +92,12 @@ public class PostController {
     // 6. 국가 필터링 API
     @Operation(summary = "국가 필터링된 게시글 조회")
     @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ACTIVE', 'AWAIT', 'TEMPORARY')")
-    @GetMapping("/filter")
+    @GetMapping("/filter/{boardType}")
     public ResponseEntity<List<PostResponseDTO>> searchPostsByCountry(
+            @PathVariable("boardType") BoardType boardType,
             @RequestParam(name = "country") String country) {
 
-        List<PostResponseDTO> filteredPosts = postService.getPostsByCountryInTitleOrContent(country);
+        List<PostResponseDTO> filteredPosts = postService.getPostsByCountryAndBoardType(boardType, country);
         return ResponseEntity.ok(filteredPosts);
     }
 


### PR DESCRIPTION
## 📝작업 내용 / 스크린샷

> 국가필터링 api에 boardType 경로변수 추가
> postResponseDto의 userId를 id로 변경, userNickname을 nickname으로 변경, userStatus 추가
> postResponseDto에서 id, nickname, userStatus, dispatchedUniversity, country를 writerInfo에 담아서 출력하도록 구조 변경