### PR TITLE
feat: 정보/자유게시글 모든 조회기능 최신순으로 정렬되도록 변경

### DIFF
--- a/src/main/java/com/on/server/domain/post/application/PostService.java
+++ b/src/main/java/com/on/server/domain/post/application/PostService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -39,6 +40,7 @@ public class PostService {
         Board board = boardRepository.findByType(boardType)
                 .orElseThrow(() -> new RuntimeException("게시판을 찾을 수 없습니다."));
         return board.getPosts().stream()
+                .sorted(Comparator.comparing(Post::getCreatedAt).reversed())
                 .map(post -> mapToPostResponseDTO(post, true)) // 댓글 수 포함
                 .collect(Collectors.toList());
     }
@@ -93,7 +95,7 @@ public class PostService {
         Board board = boardRepository.findByType(boardType)
                 .orElseThrow(() -> new RuntimeException("게시판을 찾을 수 없습니다."));
 
-        List<Post> posts = postRepository.findByUserAndBoard(user, board);
+        List<Post> posts = postRepository.findByUserAndBoardOrderByCreatedAtDesc(user, board);
         return posts.stream()
                 .map(post -> mapToPostResponseDTO(post, true)) // 댓글 수 포함
                 .collect(Collectors.toList());

--- a/src/main/java/com/on/server/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/on/server/domain/post/domain/repository/PostRepository.java
@@ -13,14 +13,14 @@ import java.util.Optional;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     // 특정 사용자와 게시판의 모든 게시글 조회
-    List<Post> findByUserAndBoard(User user, Board board);
+    List<Post> findByUserAndBoardOrderByCreatedAtDesc(User user, Board board);
 
     // 제목 또는 내용에 키워드가 포함된 게시글 검색
-    @Query("SELECT p FROM Post p WHERE p.title LIKE %:keyword% OR p.content LIKE %:keyword%")
+    @Query("SELECT p FROM Post p WHERE p.title LIKE %:keyword% OR p.content LIKE %:keyword% ORDER BY p.createdAt DESC")
     List<Post> searchPosts(@Param("keyword") String keyword);
 
     // 작성자의 국가를 기준으로 게시글 필터링
-    @Query("SELECT p FROM Post p WHERE p.board = :board AND p.user.country = :country")
+    @Query("SELECT p FROM Post p WHERE p.board = :board AND p.user.country = :country ORDER BY p.createdAt DESC")
     List<Post> findByBoardAndUserCountry(@Param("board") Board board, @Param("country") String country);
 
 


### PR DESCRIPTION
## 📝작업 내용 / 스크린샷

> 게시판 전체조회, 사용자 게시글 조회, 검색 조회, 필터링 조회 모두 최신순으로 정렬되도록 변경
