### PR TITLE
[Refactor] 정보/자유게시글 API 리팩토링

### DIFF
--- a/src/main/java/com/on/server/domain/board/application/BoardService.java
+++ b/src/main/java/com/on/server/domain/board/application/BoardService.java
@@ -1,0 +1,59 @@
+package com.on.server.domain.board.application;
+
+import com.on.server.domain.board.domain.Board;
+import com.on.server.domain.board.domain.BoardType;
+import com.on.server.domain.board.domain.repository.BoardRepository;
+import com.on.server.domain.post.domain.Post;
+import com.on.server.domain.post.domain.repository.PostRepository;
+import com.on.server.domain.post.dto.PostResponseDTO;
+import com.on.server.domain.user.domain.User;
+import com.on.server.domain.user.domain.UserStatus;
+import com.on.server.domain.user.domain.repository.UserRepository;
+import com.on.server.global.aws.s3.uuidFile.domain.UuidFile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BoardService {
+    private final BoardRepository boardRepository;
+    private final PostRepository postRepository;
+
+    // 특정 게시판의 모든 게시글 조회
+    public List<PostResponseDTO> getAllPostsByBoardType(BoardType boardType) {
+        Board board = boardRepository.findByType(boardType)
+                .orElseThrow(() -> new RuntimeException("게시판을 찾을 수 없습니다."));
+        return board.getPosts().stream()
+                .sorted(Comparator.comparing(Post::getCreatedAt).reversed())
+                .map(post -> PostResponseDTO.from(post, true))
+                .collect(Collectors.toList());
+    }
+
+    // 사용자가 특정 게시판에 작성한 모든 게시글 조회
+    public List<PostResponseDTO> getPostsByUserIdAndBoardType(User user, BoardType boardType) {
+        Board board = boardRepository.findByType(boardType)
+                .orElseThrow(() -> new RuntimeException("게시판을 찾을 수 없습니다."));
+
+        List<Post> posts = postRepository.findByUserAndBoardOrderByCreatedAtDesc(user, board);
+        return posts.stream()
+                .map(post -> PostResponseDTO.from(post, true))
+                .collect(Collectors.toList());
+    }
+
+    // 특정 게시판의 최신 게시글 4개 조회
+    public List<PostResponseDTO> getLatestPostsByBoardType(BoardType boardType) {
+        Board board = boardRepository.findByType(boardType)
+                .orElseThrow(() -> new RuntimeException("게시판을 찾을 수 없습니다."));
+
+        List<Post> posts = postRepository.findTop4ByBoardOrderByCreatedAtDesc(board);
+        return posts.stream()
+                .map(post -> PostResponseDTO.from(post, true))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/on/server/domain/board/application/BoardService.java
+++ b/src/main/java/com/on/server/domain/board/application/BoardService.java
@@ -10,7 +10,11 @@ import com.on.server.domain.user.domain.User;
 import com.on.server.domain.user.domain.UserStatus;
 import com.on.server.domain.user.domain.repository.UserRepository;
 import com.on.server.global.aws.s3.uuidFile.domain.UuidFile;
+import com.on.server.global.common.ResponseCode;
+import com.on.server.global.common.exceptions.BadRequestException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,30 +30,27 @@ public class BoardService {
     private final PostRepository postRepository;
 
     // 특정 게시판의 모든 게시글 조회
-    public List<PostResponseDTO> getAllPostsByBoardType(BoardType boardType) {
+    public Page<PostResponseDTO> getAllPostsByBoardType(BoardType boardType, Pageable pageable) {
         Board board = boardRepository.findByType(boardType)
-                .orElseThrow(() -> new RuntimeException("게시판을 찾을 수 없습니다."));
-        return board.getPosts().stream()
-                .sorted(Comparator.comparing(Post::getCreatedAt).reversed())
-                .map(post -> PostResponseDTO.from(post, true))
-                .collect(Collectors.toList());
+                .orElseThrow(() -> new BadRequestException(ResponseCode.ROW_DOES_NOT_EXIST, "게시판을 찾을 수 없습니다."));
+
+        return postRepository.findByBoardOrderByCreatedAtDesc(board, pageable)
+                .map(post -> PostResponseDTO.from(post, true));
     }
 
     // 사용자가 특정 게시판에 작성한 모든 게시글 조회
-    public List<PostResponseDTO> getPostsByUserIdAndBoardType(User user, BoardType boardType) {
+    public Page<PostResponseDTO>  getPostsByUserIdAndBoardType(User user, BoardType boardType, Pageable pageable) {
         Board board = boardRepository.findByType(boardType)
-                .orElseThrow(() -> new RuntimeException("게시판을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BadRequestException(ResponseCode.ROW_DOES_NOT_EXIST, "게시판을 찾을 수 없습니다."));
 
-        List<Post> posts = postRepository.findByUserAndBoardOrderByCreatedAtDesc(user, board);
-        return posts.stream()
-                .map(post -> PostResponseDTO.from(post, true))
-                .collect(Collectors.toList());
+        return postRepository.findByUserAndBoardOrderByCreatedAtDesc(user, board, pageable)
+                .map(post -> PostResponseDTO.from(post, true));
     }
 
     // 특정 게시판의 최신 게시글 4개 조회
     public List<PostResponseDTO> getLatestPostsByBoardType(BoardType boardType) {
         Board board = boardRepository.findByType(boardType)
-                .orElseThrow(() -> new RuntimeException("게시판을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BadRequestException(ResponseCode.ROW_DOES_NOT_EXIST, "게시판을 찾을 수 없습니다."));
 
         List<Post> posts = postRepository.findTop4ByBoardOrderByCreatedAtDesc(board);
         return posts.stream()

--- a/src/main/java/com/on/server/domain/board/presentation/BoardController.java
+++ b/src/main/java/com/on/server/domain/board/presentation/BoardController.java
@@ -9,6 +9,7 @@ import com.on.server.global.security.SecurityService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -37,7 +38,7 @@ public class BoardController {
     @GetMapping("/{boardType}")
     public ResponseEntity<Page<PostResponseDTO>> getAllPostsByBoardType(
             @PathVariable("boardType") BoardType boardType,
-            Pageable pageable
+            @ParameterObject Pageable pageable
     ) {
         Page<PostResponseDTO> posts = boardService.getAllPostsByBoardType(boardType, pageable);
 
@@ -50,7 +51,7 @@ public class BoardController {
     @GetMapping("/user/{boardType}")
     public ResponseEntity<Page<PostResponseDTO>> getPostsByUserIdAndBoardType(
             @PathVariable("boardType") BoardType boardType,
-            Pageable pageable,
+            @ParameterObject Pageable pageable,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
         User user = securityService.getUserByUserDetails(userDetails);

--- a/src/main/java/com/on/server/domain/board/presentation/BoardController.java
+++ b/src/main/java/com/on/server/domain/board/presentation/BoardController.java
@@ -1,0 +1,68 @@
+package com.on.server.domain.board.presentation;
+
+import com.on.server.domain.board.application.BoardService;
+import com.on.server.domain.board.domain.BoardType;
+import com.on.server.domain.post.dto.PostResponseDTO;
+import com.on.server.domain.user.domain.User;
+import com.on.server.global.common.CommonResponse;
+import com.on.server.global.security.SecurityService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "게시글 작성")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/post")
+public class BoardController {
+
+    private final BoardService boardService;
+    private final SecurityService securityService;
+
+    // 특정 게시판(boardType)의 모든 게시글을 조회
+    @Operation(summary = "특정 게시판의 모든 게시글 조회")
+    @PreAuthorize("@securityService.isNotTemporaryUser()")
+    @GetMapping("/{boardType}")
+    public ResponseEntity<List<PostResponseDTO>> getAllPostsByBoardType(
+            @PathVariable("boardType") BoardType boardType
+    ) {
+        List<PostResponseDTO> posts = boardService.getAllPostsByBoardType(boardType);
+
+        return ResponseEntity.ok(posts);
+    }
+
+    // 자기가 특정 게시판에 작성한 모든 게시글 조회
+    @Operation(summary = "사용자가 특정 게시판에 작성한 모든 게시글 조회")
+    @PreAuthorize("@securityService.isNotTemporaryUser()")
+    @GetMapping("/user/{boardType}")
+    public ResponseEntity<List<PostResponseDTO>> getPostsByUserIdAndBoardType(
+            @PathVariable("boardType") BoardType boardType,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        User user = securityService.getUserByUserDetails(userDetails);
+        List<PostResponseDTO> posts = boardService.getPostsByUserIdAndBoardType(user, boardType);
+
+        return ResponseEntity.ok(posts);
+    }
+
+    // 특정 게시판의 최신 게시글 4개 조회
+    @Operation(summary = "특정 게시판의 최신 게시글 4개 조회")
+    @PreAuthorize("@securityService.isNotTemporaryUser()")
+    @GetMapping("/recent/{boardType}")
+    public ResponseEntity<List<PostResponseDTO>> getLatestPosts(
+            @PathVariable("boardType") BoardType boardType
+    ) {
+        List<PostResponseDTO> latestPosts = boardService.getLatestPostsByBoardType(boardType);
+        return ResponseEntity.ok(latestPosts);
+    }
+}

--- a/src/main/java/com/on/server/domain/board/presentation/BoardController.java
+++ b/src/main/java/com/on/server/domain/board/presentation/BoardController.java
@@ -9,6 +9,8 @@ import com.on.server.global.security.SecurityService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -33,10 +35,11 @@ public class BoardController {
     @Operation(summary = "특정 게시판의 모든 게시글 조회")
     @PreAuthorize("@securityService.isNotTemporaryUser()")
     @GetMapping("/{boardType}")
-    public ResponseEntity<List<PostResponseDTO>> getAllPostsByBoardType(
-            @PathVariable("boardType") BoardType boardType
+    public ResponseEntity<Page<PostResponseDTO>> getAllPostsByBoardType(
+            @PathVariable("boardType") BoardType boardType,
+            Pageable pageable
     ) {
-        List<PostResponseDTO> posts = boardService.getAllPostsByBoardType(boardType);
+        Page<PostResponseDTO> posts = boardService.getAllPostsByBoardType(boardType, pageable);
 
         return ResponseEntity.ok(posts);
     }
@@ -45,13 +48,14 @@ public class BoardController {
     @Operation(summary = "사용자가 특정 게시판에 작성한 모든 게시글 조회")
     @PreAuthorize("@securityService.isNotTemporaryUser()")
     @GetMapping("/user/{boardType}")
-    public ResponseEntity<List<PostResponseDTO>> getPostsByUserIdAndBoardType(
+    public ResponseEntity<Page<PostResponseDTO>> getPostsByUserIdAndBoardType(
             @PathVariable("boardType") BoardType boardType,
+            Pageable pageable,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
         User user = securityService.getUserByUserDetails(userDetails);
-        List<PostResponseDTO> posts = boardService.getPostsByUserIdAndBoardType(user, boardType);
 
+        Page<PostResponseDTO> posts = boardService.getPostsByUserIdAndBoardType(user, boardType, pageable);
         return ResponseEntity.ok(posts);
     }
 

--- a/src/main/java/com/on/server/domain/post/application/PostService.java
+++ b/src/main/java/com/on/server/domain/post/application/PostService.java
@@ -18,6 +18,8 @@ import com.on.server.global.common.ResponseCode;
 import com.on.server.global.common.exceptions.BadRequestException;
 import com.on.server.global.common.exceptions.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -101,11 +103,9 @@ public class PostService {
     }
 
     // 게시글 검색 기능
-    public List<PostResponseDTO> searchPosts(String keyword) {
-        List<Post> posts = postRepository.searchPosts(keyword);
-        return posts.stream()
-                .map(post -> PostResponseDTO.from(post, true))
-                .collect(Collectors.toList());
+    public Page<PostResponseDTO> searchPosts(String keyword, Pageable pageable) {
+        Page<Post> posts = postRepository.searchPosts(keyword, pageable);
+        return posts.map(post -> PostResponseDTO.from(post, true));
     }
 
     // 국가 필터링 메서드

--- a/src/main/java/com/on/server/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/on/server/domain/post/domain/repository/PostRepository.java
@@ -3,6 +3,8 @@ package com.on.server.domain.post.domain.repository;
 import com.on.server.domain.board.domain.Board;
 import com.on.server.domain.post.domain.Post;
 import com.on.server.domain.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,12 +14,15 @@ import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    // 특정 사용자와 게시판의 모든 게시글 조회
-    List<Post> findByUserAndBoardOrderByCreatedAtDesc(User user, Board board);
+    // 특정 게시판의 모든 게시글 조회
+    Page<Post> findByBoardOrderByCreatedAtDesc(Board board, Pageable pageable);
+
+    // 특정 사용자가 게시판에 작성한 모든 게시글 조회
+    Page<Post> findByUserAndBoardOrderByCreatedAtDesc(User user, Board board, Pageable pageable);
 
     // 제목 또는 내용에 키워드가 포함된 게시글 검색
     @Query("SELECT p FROM Post p WHERE p.title LIKE %:keyword% OR p.content LIKE %:keyword% ORDER BY p.createdAt DESC")
-    List<Post> searchPosts(@Param("keyword") String keyword);
+    Page<Post> searchPosts(@Param("keyword") String keyword, Pageable pageable);
 
     // 작성자의 국가를 기준으로 게시글 필터링
     @Query("SELECT p FROM Post p WHERE p.board = :board AND p.user.country = :country ORDER BY p.createdAt DESC")

--- a/src/main/java/com/on/server/domain/post/dto/PostRequestDTO.java
+++ b/src/main/java/com/on/server/domain/post/dto/PostRequestDTO.java
@@ -13,9 +13,6 @@ import java.util.List;
 @NoArgsConstructor
 public class PostRequestDTO {
 
-    // 작성자 ID
-    private Long id;
-
     // 게시글 제목
     private String title;
 

--- a/src/main/java/com/on/server/domain/post/dto/WriterInfo.java
+++ b/src/main/java/com/on/server/domain/post/dto/WriterInfo.java
@@ -1,0 +1,28 @@
+package com.on.server.domain.post.dto;
+
+import com.on.server.domain.user.domain.UserStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class WriterInfo {
+    // 작성자 ID
+    private Long id;
+
+    // 작성자 닉네임
+    private String nickname;
+
+    // 파견국가
+    private String country;
+
+    // 파견교
+    private String dispatchedUniversity;
+
+    // 작성자 상태
+    private UserStatus userStatus;
+}

--- a/src/main/java/com/on/server/domain/post/presentation/PostController.java
+++ b/src/main/java/com/on/server/domain/post/presentation/PostController.java
@@ -45,9 +45,9 @@ public class PostController {
             @AuthenticationPrincipal UserDetails userDetails)
     {
         User user = securityService.getUserByUserDetails(userDetails);
-        PostResponseDTO createdPost = postService.createPost(boardType, requestDTO, imageFiles, user);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(createdPost);
+        PostResponseDTO createdPost = postService.createPost(boardType, requestDTO, imageFiles, user);
+        return ResponseEntity.ok(createdPost);
     }
 
     // 특정 게시판(boardType) 내의 특정 게시글(postId)을 조회
@@ -59,7 +59,6 @@ public class PostController {
             @PathVariable("postId") Long postId
     ) {
         PostResponseDTO post = postService.getPostById(boardType, postId);
-
         return ResponseEntity.ok(post);
     }
 
@@ -74,9 +73,9 @@ public class PostController {
             @AuthenticationPrincipal UserDetails userDetails)
     {
         User user = securityService.getUserByUserDetails(userDetails);
-        postService.deletePost(user, boardType, postId);
 
-        return ResponseEntity.noContent().build();
+        postService.deletePost(user, boardType, postId);
+        return ResponseEntity.ok().build();
     }
 
 

--- a/src/main/java/com/on/server/domain/post/presentation/PostController.java
+++ b/src/main/java/com/on/server/domain/post/presentation/PostController.java
@@ -33,19 +33,7 @@ public class PostController {
     private final PostService postService;
     private final SecurityService securityService;
 
-    // 1. 특정 게시판(boardType)의 모든 게시글을 조회
-    @Operation(summary = "특정 게시판의 모든 게시글 조회")
-    @PreAuthorize("@securityService.isNotTemporaryUser()")
-    @GetMapping("/{boardType}")
-    public ResponseEntity<List<PostResponseDTO>> getAllPostsByBoardType(
-            @PathVariable("boardType") BoardType boardType
-    ) {
-        List<PostResponseDTO> posts = postService.getAllPostsByBoardType(boardType);
-
-        return ResponseEntity.ok(posts);
-    }
-
-    // 2. 특정 게시판(boardType)에 새로운 게시글을 작성
+    // 특정 게시판(boardType)에 새로운 게시글을 작성
     @Operation(summary = "특정 게시판에 새로운 게시글 작성")
     @PreAuthorize("@securityService.isNotTemporaryUser()")
     @PostMapping(value = "/{boardType}",
@@ -62,7 +50,7 @@ public class PostController {
         return ResponseEntity.status(HttpStatus.CREATED).body(createdPost);
     }
 
-    // 3. 특정 게시판(boardType) 내의 특정 게시글(postId)을 조회
+    // 특정 게시판(boardType) 내의 특정 게시글(postId)을 조회
     @Operation(summary = "특정 게시판 내의 특정 게시글 조회")
     @PreAuthorize("@securityService.isNotTemporaryUser()")
     @GetMapping("/{boardType}/{postId}")
@@ -75,21 +63,8 @@ public class PostController {
         return ResponseEntity.ok(post);
     }
 
-    // 4. 자기가 특정 게시판에 작성한 모든 게시글 조회
-    @Operation(summary = "사용자가 특정 게시판에 작성한 모든 게시글 조회")
-    @PreAuthorize("@securityService.isNotTemporaryUser()")
-    @GetMapping("/user/{boardType}")
-    public ResponseEntity<List<PostResponseDTO>> getPostsByUserIdAndBoardType(
-            @PathVariable("boardType") BoardType boardType,
-            @AuthenticationPrincipal UserDetails userDetails
-    ) {
-        User user = securityService.getUserByUserDetails(userDetails);
-        List<PostResponseDTO> posts = postService.getPostsByUserIdAndBoardType(user, boardType);
 
-        return ResponseEntity.ok(posts);
-    }
-
-    // 5. 자기가 특정 게시판에 작성한 특정 게시글(postId)을 삭제
+    // 자기가 특정 게시판에 작성한 특정 게시글(postId)을 삭제
     @Operation(summary = "사용자가 특정 게시판에 작성한 특정 게시글 삭제")
     @PreAuthorize("@securityService.isNotTemporaryUser()")
     @DeleteMapping("/user/{boardType}/{postId}")
@@ -105,7 +80,7 @@ public class PostController {
     }
 
 
-    // 6. 국가 필터링 API
+    // 국가 필터링 API
     @Operation(summary = "국가 필터링된 게시글 조회")
     @PreAuthorize("@securityService.isNotTemporaryUser()")
     @GetMapping("/filter/{boardType}")
@@ -118,7 +93,7 @@ public class PostController {
     }
 
 
-    // 7. 게시글 검색 API
+    // 게시글 검색 API
     @Operation(summary = "게시글 검색")
     @PreAuthorize("@securityService.isNotTemporaryUser()")
     @GetMapping("/search")
@@ -128,16 +103,4 @@ public class PostController {
         List<PostResponseDTO> posts = postService.searchPosts(keyword);
         return ResponseEntity.ok(posts);
     }
-
-    // 8. 특정 게시판의 최신 게시글 4개 조회
-    @Operation(summary = "특정 게시판의 최신 게시글 4개 조회")
-    @PreAuthorize("@securityService.isNotTemporaryUser()")
-    @GetMapping("/recent/{boardType}")
-    public ResponseEntity<List<PostResponseDTO>> getLatestPosts(
-            @PathVariable("boardType") BoardType boardType
-    ) {
-        List<PostResponseDTO> latestPosts = postService.getLatestPostsByBoardType(boardType);
-        return ResponseEntity.ok(latestPosts);
-    }
-
 }

--- a/src/main/java/com/on/server/domain/post/presentation/PostController.java
+++ b/src/main/java/com/on/server/domain/post/presentation/PostController.java
@@ -11,6 +11,8 @@ import com.on.server.global.security.SecurityService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -96,10 +98,11 @@ public class PostController {
     @Operation(summary = "게시글 검색")
     @PreAuthorize("@securityService.isNotTemporaryUser()")
     @GetMapping("/search")
-    public ResponseEntity<List<PostResponseDTO>> searchPosts(
-            @RequestParam("keyword") String keyword
+    public ResponseEntity<Page<PostResponseDTO>>searchPosts(
+            @RequestParam("keyword") String keyword,
+            Pageable pageable
     ) {
-        List<PostResponseDTO> posts = postService.searchPosts(keyword);
+        Page<PostResponseDTO> posts = postService.searchPosts(keyword, pageable);
         return ResponseEntity.ok(posts);
     }
 }

--- a/src/main/java/com/on/server/domain/post/presentation/PostController.java
+++ b/src/main/java/com/on/server/domain/post/presentation/PostController.java
@@ -11,6 +11,7 @@ import com.on.server.global.security.SecurityService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -100,7 +101,7 @@ public class PostController {
     @GetMapping("/search")
     public ResponseEntity<Page<PostResponseDTO>>searchPosts(
             @RequestParam("keyword") String keyword,
-            Pageable pageable
+            @ParameterObject Pageable pageable
     ) {
         Page<PostResponseDTO> posts = postService.searchPosts(keyword, pageable);
         return ResponseEntity.ok(posts);


### PR DESCRIPTION
## 📝작업 내용 / 스크린샷

> - ResponseDTO에 from 메서드 추가
> - WriterInfo 별도 클래스로 분리
> - UserDetails에서 User 객체를 가져오도록 수정
> - PostRequestDTO에서 사용자id 제거  
> - BoardController, BoardService로 기능 이동
>   - 게시판의 모든 게시글 조회
>   - 사용자가 게시판 작성한 모든 게시글 조회
>   - 게시판의 최신 게시글 4개 조회
> - Response Entity 응답 상태코드 ok로 통일
> - GlobalExceptionHandler로 예외처리 변경
> - 정보/자유게시글 조회기능에 paging 추가