### PR TITLE
[Refactor] 댓글 및 답글 API 리팩토링

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,7 +38,6 @@ jobs:
           touch $OCCUPY_SECRET_DIR/$OCCUPY_SECRET_DIR_FILE_NAME
           
           echo "$OCCUPY_SECRET" > $OCCUPY_SECRET_DIR/$OCCUPY_SECRET_DIR_FILE_NAME
-
       # firebase 폴더 내 json 파일 github secret에서 복사해 오기
       - name: Copy firebase
         env:
@@ -49,7 +48,6 @@ jobs:
         run: |
           mkdir -p $OCCUPY_FIREBASE_DIR
           echo "$OCCUPY_FIREBASE" > $OCCUPY_FIREBASE_DIR/$OCCUPY_FIREBASE_DIR_FILE_NAME
-
       # gradlew 실행 권한 부여
       - name: Run chmod to make gradlew executable
         run: chmod +x ./gradlew
@@ -61,12 +59,11 @@ jobs:
         shell: bash
 
       - name: Upload Build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifacts
           path: |
             build/libs/*.jar
-
       - name: Upload project code
         uses: appleboy/scp-action@master
         with:
@@ -84,7 +81,7 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-artifacts
 

--- a/src/main/java/com/on/server/domain/comment/application/CommentService.java
+++ b/src/main/java/com/on/server/domain/comment/application/CommentService.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 public class CommentService {
 
     private final CommentRepository commentRepository;
-    private final UserRepository userRepository;
     private final PostRepository postRepository;
 
     // 특정 게시글의 모든 댓글 및 답글 조회
@@ -51,9 +50,7 @@ public class CommentService {
 
 
     // 새로운 댓글 작성
-    public CommentResponseDTO createComment(Long postId, CommentRequestDTO commentRequestDTO) {
-        User user = userRepository.findById(commentRequestDTO.getId())
-                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+    public CommentResponseDTO createComment(Long postId, CommentRequestDTO commentRequestDTO, User user) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
 
@@ -75,9 +72,7 @@ public class CommentService {
     }
 
     // 답글 작성
-    public CommentResponseDTO createReply(Long parentCommentId, CommentRequestDTO commentRequestDTO) {
-        User user = userRepository.findById(commentRequestDTO.getId())
-                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+    public CommentResponseDTO createReply(Long parentCommentId, CommentRequestDTO commentRequestDTO, User user) {
         Comment parentComment = commentRepository.findById(parentCommentId)
                 .orElseThrow(() -> new RuntimeException("부모 댓글을 찾을 수 없습니다."));
 
@@ -99,7 +94,7 @@ public class CommentService {
         return CommentResponseDTO.from(reply);
     }
 
-    // 익명 인덱스 생성 로직
+    // 익명 인덱스 생성
     private Integer generateAnonymousIndex(User user, Post post) {
         List<Comment> userComments = commentRepository.findByUserAndPostAndIsAnonymousTrue(user, post);
         if (!userComments.isEmpty()) {

--- a/src/main/java/com/on/server/domain/comment/application/CommentService.java
+++ b/src/main/java/com/on/server/domain/comment/application/CommentService.java
@@ -35,7 +35,7 @@ public class CommentService {
                 .orElseThrow(() -> new BadRequestException(ResponseCode.ROW_DOES_NOT_EXIST, "게시글을 찾을 수 없습니다. ID: " + postId));
 
         Page<Comment> comments = commentRepository.findByPost(post, pageable);
-        return comments.map(CommentResponseDTO::from);
+        return comments.map(comment -> CommentResponseDTO.from(comment, commentRepository));
     }
 
     // 특정 댓글의 모든 답글 조회
@@ -45,7 +45,7 @@ public class CommentService {
                 .orElseThrow(() -> new BadRequestException(ResponseCode.ROW_DOES_NOT_EXIST, "댓글을 찾을 수 없습니다. ID: " + commentId));
 
         Page<Comment> replies = commentRepository.findByParentComment(parentComment, pageable);
-        return replies.map(CommentResponseDTO::from);
+        return replies.map(reply -> CommentResponseDTO.from(reply, commentRepository));
     }
 
 
@@ -68,7 +68,7 @@ public class CommentService {
                 .build();
 
         commentRepository.save(comment);
-        return CommentResponseDTO.from(comment);
+        return CommentResponseDTO.from(comment, commentRepository);
     }
 
     // 답글 작성
@@ -91,7 +91,7 @@ public class CommentService {
                 .build();
 
         commentRepository.save(reply);
-        return CommentResponseDTO.from(reply);
+        return CommentResponseDTO.from(reply, commentRepository);
     }
 
     // 익명 인덱스 생성

--- a/src/main/java/com/on/server/domain/comment/application/CommentService.java
+++ b/src/main/java/com/on/server/domain/comment/application/CommentService.java
@@ -12,6 +12,8 @@ import com.on.server.domain.user.domain.repository.UserRepository;
 import com.on.server.global.common.exceptions.BadRequestException;
 import com.on.server.global.common.ResponseCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,26 +30,22 @@ public class CommentService {
 
     // 특정 게시글의 모든 댓글 및 답글 조회
     @Transactional(readOnly = true)
-    public List<CommentResponseDTO> getAllCommentsAndRepliesByPostId(Long postId) {
+    public Page<CommentResponseDTO> getAllCommentsAndRepliesByPostId(Long postId, Pageable pageable) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new BadRequestException(ResponseCode.ROW_DOES_NOT_EXIST, "게시글을 찾을 수 없습니다. ID: " + postId));
 
-        List<Comment> comments = commentRepository.findByPost(post);
-        return comments.stream()
-                .map(CommentResponseDTO::from)
-                .collect(Collectors.toList());
+        Page<Comment> comments = commentRepository.findByPost(post, pageable);
+        return comments.map(CommentResponseDTO::from);
     }
 
     // 특정 댓글의 모든 답글 조회
     @Transactional(readOnly = true)
-    public List<CommentResponseDTO> getAllRepliesByCommentId(Long commentId) {
+    public Page<CommentResponseDTO> getAllRepliesByCommentId(Long commentId, Pageable pageable) {
         Comment parentComment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new BadRequestException(ResponseCode.ROW_DOES_NOT_EXIST, "댓글을 찾을 수 없습니다. ID: " + commentId));
 
-        List<Comment> replies = commentRepository.findByParentComment(parentComment);
-        return replies.stream()
-                .map(CommentResponseDTO::from)
-                .collect(Collectors.toList());
+        Page<Comment> replies = commentRepository.findByParentComment(parentComment, pageable);
+        return replies.map(CommentResponseDTO::from);
     }
 
 

--- a/src/main/java/com/on/server/domain/comment/application/CommentService.java
+++ b/src/main/java/com/on/server/domain/comment/application/CommentService.java
@@ -9,6 +9,8 @@ import com.on.server.domain.post.domain.Post;
 import com.on.server.domain.post.domain.repository.PostRepository;
 import com.on.server.domain.user.domain.User;
 import com.on.server.domain.user.domain.repository.UserRepository;
+import com.on.server.global.common.exceptions.BadRequestException;
+import com.on.server.global.common.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +30,7 @@ public class CommentService {
     @Transactional(readOnly = true)
     public List<CommentResponseDTO> getAllCommentsAndRepliesByPostId(Long postId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BadRequestException(ResponseCode.ROW_DOES_NOT_EXIST, "게시글을 찾을 수 없습니다. ID: " + postId));
 
         List<Comment> comments = commentRepository.findByPost(post);
         return comments.stream()
@@ -40,7 +42,7 @@ public class CommentService {
     @Transactional(readOnly = true)
     public List<CommentResponseDTO> getAllRepliesByCommentId(Long commentId) {
         Comment parentComment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new RuntimeException("댓글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BadRequestException(ResponseCode.ROW_DOES_NOT_EXIST, "댓글을 찾을 수 없습니다. ID: " + commentId));
 
         List<Comment> replies = commentRepository.findByParentComment(parentComment);
         return replies.stream()
@@ -52,7 +54,7 @@ public class CommentService {
     // 새로운 댓글 작성
     public CommentResponseDTO createComment(Long postId, CommentRequestDTO commentRequestDTO, User user) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BadRequestException(ResponseCode.ROW_DOES_NOT_EXIST, "게시글을 찾을 수 없습니다. ID: " + postId));
 
         Integer anonymousIndex = null;
         if (commentRequestDTO.isAnonymous()) {
@@ -74,7 +76,7 @@ public class CommentService {
     // 답글 작성
     public CommentResponseDTO createReply(Long parentCommentId, CommentRequestDTO commentRequestDTO, User user) {
         Comment parentComment = commentRepository.findById(parentCommentId)
-                .orElseThrow(() -> new RuntimeException("부모 댓글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BadRequestException(ResponseCode.ROW_DOES_NOT_EXIST, "부모 댓글을 찾을 수 없습니다. ID: " + parentCommentId));
 
         Integer anonymousIndex = null;
         if (commentRequestDTO.isAnonymous()) {

--- a/src/main/java/com/on/server/domain/comment/domain/Comment.java
+++ b/src/main/java/com/on/server/domain/comment/domain/Comment.java
@@ -36,10 +36,6 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "parent_id")
     private Comment parentComment;
 
-    // 자식 답글
-    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Comment> childrenComment = new ArrayList<>();
-
     @Column(name = "anonymous_index")
     private Integer anonymousIndex;
 }

--- a/src/main/java/com/on/server/domain/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/com/on/server/domain/comment/domain/repository/CommentRepository.java
@@ -4,6 +4,8 @@ import com.on.server.domain.comment.domain.Comment;
 import com.on.server.domain.post.domain.Post;
 import com.on.server.domain.user.domain.User;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,10 +14,10 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     // 게시글의 모든 댓글 및 답글 조회
-    List<Comment> findByPost(Post post);
+    Page<Comment> findByPost(Post post, Pageable pageable);
 
     // 댓글에 대한 답글 조회
-    List<Comment> findByParentComment(Comment parentComment);
+    Page<Comment> findByParentComment(Comment parentComment, Pageable pageable);
 
     // 사용자가 게시글에 작성한 익명 댓글 조회
     List<Comment> findByUserAndPostAndIsAnonymousTrue(User user, Post post);

--- a/src/main/java/com/on/server/domain/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/com/on/server/domain/comment/domain/repository/CommentRepository.java
@@ -25,4 +25,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     // 해당 게시글에 작성된 모든 익명 댓글의 익명 인덱스를 조회
     @Query("SELECT c.anonymousIndex FROM Comment c WHERE c.post = :post AND c.anonymousIndex IS NOT NULL")
     List<Integer> findAnonymousIndicesByPost(@Param("post") Post post);
+
+    // 특정 댓글에 답글이 몇 개인지 카운트
+    int countByParentComment(Comment parentComment);
 }

--- a/src/main/java/com/on/server/domain/comment/dto/CommentRequestDTO.java
+++ b/src/main/java/com/on/server/domain/comment/dto/CommentRequestDTO.java
@@ -9,9 +9,6 @@ import lombok.Setter;
 @NoArgsConstructor
 public class CommentRequestDTO {
 
-    // 작성자 ID
-    private Long id;
-
     // 익명 여부
     @JsonProperty("anonymous")
     private boolean isAnonymous;

--- a/src/main/java/com/on/server/domain/comment/dto/CommentResponseDTO.java
+++ b/src/main/java/com/on/server/domain/comment/dto/CommentResponseDTO.java
@@ -1,5 +1,6 @@
 package com.on.server.domain.comment.dto;
 
+import com.on.server.domain.comment.domain.Comment;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,15 +36,32 @@ public class CommentResponseDTO {
     private Integer replyCount;
 
 
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class WriterInfo {
-        // 작성자 ID
-        private Long id;
+    public static CommentResponseDTO from(Comment comment) {
+        boolean isReply = comment.getParentComment() != null;
 
-        // 작성자 닉네임
-        private String nickname;
+        Long replyId = null;
+
+        if (isReply) {
+            List<Comment> siblings = comment.getParentComment().getChildrenComment();
+            replyId = (long) (siblings.indexOf(comment) + 1);
+        }
+
+        String nickname = comment.getIsAnonymous() ? "익명" + comment.getAnonymousIndex() : comment.getUser().getNickname();
+
+        WriterInfo writerInfo = WriterInfo.builder()
+                .id(comment.getUser().getId())
+                .nickname(nickname)
+                .build();
+
+        return CommentResponseDTO.builder()
+                .commentId(isReply ? comment.getParentComment().getId() : comment.getId())
+                .replyId(replyId)
+                .postId(comment.getPost().getId())
+                .writerInfo(writerInfo)
+                .isAnonymous(comment.getIsAnonymous())
+                .contents(comment.getContents())
+                .replyCount(comment.getChildrenComment() != null ? comment.getChildrenComment().size() : 0)
+                .build();
     }
+
 }

--- a/src/main/java/com/on/server/domain/comment/dto/WriterInfo.java
+++ b/src/main/java/com/on/server/domain/comment/dto/WriterInfo.java
@@ -1,0 +1,18 @@
+package com.on.server.domain.comment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class WriterInfo {
+    // 작성자 ID
+    private Long id;
+
+    // 작성자 닉네임
+    private String nickname;
+}

--- a/src/main/java/com/on/server/domain/comment/presentation/CommentController.java
+++ b/src/main/java/com/on/server/domain/comment/presentation/CommentController.java
@@ -60,7 +60,7 @@ public class CommentController {
         User user = securityService.getUserByUserDetails(userDetails);
 
         CommentResponseDTO createdComment = commentService.createComment(postId, commentRequestDTO, user);
-        return ResponseEntity.status(HttpStatus.CREATED).body(createdComment);
+        return ResponseEntity.ok(createdComment);
     }
 
     // 4. 특정 댓글(CommentId)에 답글 작성
@@ -75,7 +75,7 @@ public class CommentController {
         User user = securityService.getUserByUserDetails(userDetails);
 
         CommentResponseDTO createdReply = commentService.createReply(commentId, commentRequestDTO, user);
-        return ResponseEntity.status(HttpStatus.CREATED).body(createdReply);
+        return ResponseEntity.ok(createdReply);
     }
 }
 

--- a/src/main/java/com/on/server/domain/comment/presentation/CommentController.java
+++ b/src/main/java/com/on/server/domain/comment/presentation/CommentController.java
@@ -8,6 +8,8 @@ import com.on.server.global.security.SecurityService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -30,10 +32,11 @@ public class CommentController {
     @Operation(summary = "특정 게시글의 모든 댓글 및 답글 조회")
     @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ACTIVE', 'AWAIT', 'TEMPORARY')")
     @GetMapping("/{postId}")
-    public ResponseEntity<List<CommentResponseDTO>> getAllCommentsAndRepliesByPostId(
-            @PathVariable("postId") Long postId
+    public ResponseEntity<Page<CommentResponseDTO>> getAllCommentsAndRepliesByPostId(
+            @PathVariable("postId") Long postId,
+            Pageable pageable
     ) {
-        List<CommentResponseDTO> comments = commentService.getAllCommentsAndRepliesByPostId(postId);
+        Page<CommentResponseDTO> comments = commentService.getAllCommentsAndRepliesByPostId(postId, pageable);
         return ResponseEntity.ok(comments);
     }
 
@@ -41,10 +44,11 @@ public class CommentController {
     @Operation(summary = "특정 댓글의 모든 답글 조회")
     @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ACTIVE', 'AWAIT', 'TEMPORARY')")
     @GetMapping("/{commentId}/reply")
-    public ResponseEntity<List<CommentResponseDTO>> getAllRepliesByCommentId(
-            @PathVariable("commentId") Long commentId
+    public ResponseEntity<Page<CommentResponseDTO>> getAllRepliesByCommentId(
+            @PathVariable("commentId") Long commentId,
+            Pageable pageable
     ) {
-        List<CommentResponseDTO> replies = commentService.getAllRepliesByCommentId(commentId);
+        Page<CommentResponseDTO> replies = commentService.getAllRepliesByCommentId(commentId, pageable);
         return ResponseEntity.ok(replies);
     }
 

--- a/src/main/java/com/on/server/domain/comment/presentation/CommentController.java
+++ b/src/main/java/com/on/server/domain/comment/presentation/CommentController.java
@@ -3,6 +3,8 @@ package com.on.server.domain.comment.presentation;
 import com.on.server.domain.comment.application.CommentService;
 import com.on.server.domain.comment.dto.CommentRequestDTO;
 import com.on.server.domain.comment.dto.CommentResponseDTO;
+import com.on.server.domain.user.domain.User;
+import com.on.server.global.security.SecurityService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -22,12 +24,15 @@ import java.util.List;
 public class CommentController {
 
     private final CommentService commentService;
+    private final SecurityService securityService;
 
     // 1. 특정 게시글(postId)의 모든 댓글 및 답글 조회
     @Operation(summary = "특정 게시글의 모든 댓글 및 답글 조회")
     @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ACTIVE', 'AWAIT', 'TEMPORARY')")
     @GetMapping("/{postId}")
-    public ResponseEntity<List<CommentResponseDTO>> getAllCommentsAndRepliesByPostId(@PathVariable("postId") Long postId, @AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<List<CommentResponseDTO>> getAllCommentsAndRepliesByPostId(
+            @PathVariable("postId") Long postId
+    ) {
         List<CommentResponseDTO> comments = commentService.getAllCommentsAndRepliesByPostId(postId);
         return ResponseEntity.ok(comments);
     }
@@ -36,7 +41,9 @@ public class CommentController {
     @Operation(summary = "특정 댓글의 모든 답글 조회")
     @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ACTIVE', 'AWAIT', 'TEMPORARY')")
     @GetMapping("/{commentId}/reply")
-    public ResponseEntity<List<CommentResponseDTO>> getAllRepliesByCommentId(@PathVariable("commentId") Long commentId, @AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<List<CommentResponseDTO>> getAllRepliesByCommentId(
+            @PathVariable("commentId") Long commentId
+    ) {
         List<CommentResponseDTO> replies = commentService.getAllRepliesByCommentId(commentId);
         return ResponseEntity.ok(replies);
     }
@@ -45,10 +52,14 @@ public class CommentController {
     @Operation(summary = "특정 게시글에 댓글 작성")
     @PostMapping("/{postId}")
     @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ACTIVE')")
-    public ResponseEntity<CommentResponseDTO> createComment(@PathVariable("postId") Long postId,
-                                                            @RequestBody CommentRequestDTO commentRequestDTO,
-                                                            @AuthenticationPrincipal UserDetails userDetails) {
-        CommentResponseDTO createdComment = commentService.createComment(postId, commentRequestDTO);
+    public ResponseEntity<CommentResponseDTO> createComment(
+            @PathVariable("postId") Long postId,
+            @RequestBody CommentRequestDTO commentRequestDTO,
+            @AuthenticationPrincipal UserDetails userDetails)
+    {
+        User user = securityService.getUserByUserDetails(userDetails);
+
+        CommentResponseDTO createdComment = commentService.createComment(postId, commentRequestDTO, user);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdComment);
     }
 
@@ -56,10 +67,14 @@ public class CommentController {
     @Operation(summary = "특정 댓글에 답글 작성")
     @PostMapping("/{commentId}/reply")
     @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ACTIVE')")
-    public ResponseEntity<CommentResponseDTO> createReply(@PathVariable("commentId") Long commentId,
-                                                          @RequestBody CommentRequestDTO commentRequestDTO,
-                                                          @AuthenticationPrincipal UserDetails userDetails) {
-        CommentResponseDTO createdReply = commentService.createReply(commentId, commentRequestDTO);
+    public ResponseEntity<CommentResponseDTO> createReply(
+            @PathVariable("commentId") Long commentId,
+            @RequestBody CommentRequestDTO commentRequestDTO,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        User user = securityService.getUserByUserDetails(userDetails);
+
+        CommentResponseDTO createdReply = commentService.createReply(commentId, commentRequestDTO, user);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdReply);
     }
 }

--- a/src/main/java/com/on/server/domain/comment/presentation/CommentController.java
+++ b/src/main/java/com/on/server/domain/comment/presentation/CommentController.java
@@ -30,7 +30,7 @@ public class CommentController {
 
     // 1. 특정 게시글(postId)의 모든 댓글 및 답글 조회
     @Operation(summary = "특정 게시글의 모든 댓글 및 답글 조회")
-    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ACTIVE', 'AWAIT', 'TEMPORARY')")
+    @PreAuthorize("@securityService.isNotTemporaryUser()")
     @GetMapping("/{postId}")
     public ResponseEntity<Page<CommentResponseDTO>> getAllCommentsAndRepliesByPostId(
             @PathVariable("postId") Long postId,
@@ -42,7 +42,7 @@ public class CommentController {
 
     // 2. 특정 댓글(commentId)의 모든 답글 조회
     @Operation(summary = "특정 댓글의 모든 답글 조회")
-    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ACTIVE', 'AWAIT', 'TEMPORARY')")
+    @PreAuthorize("@securityService.isNotTemporaryUser()")
     @GetMapping("/{commentId}/reply")
     public ResponseEntity<Page<CommentResponseDTO>> getAllRepliesByCommentId(
             @PathVariable("commentId") Long commentId,
@@ -55,7 +55,7 @@ public class CommentController {
     // 3. 특정 게시글(postId)에 새로운 댓글을 작성
     @Operation(summary = "특정 게시글에 댓글 작성")
     @PostMapping("/{postId}")
-    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ACTIVE')")
+    @PreAuthorize("@securityService.isNotTemporaryUser()")
     public ResponseEntity<CommentResponseDTO> createComment(
             @PathVariable("postId") Long postId,
             @RequestBody CommentRequestDTO commentRequestDTO,
@@ -70,7 +70,7 @@ public class CommentController {
     // 4. 특정 댓글(CommentId)에 답글 작성
     @Operation(summary = "특정 댓글에 답글 작성")
     @PostMapping("/{commentId}/reply")
-    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ACTIVE')")
+    @PreAuthorize("@securityService.isNotTemporaryUser()")
     public ResponseEntity<CommentResponseDTO> createReply(
             @PathVariable("commentId") Long commentId,
             @RequestBody CommentRequestDTO commentRequestDTO,

--- a/src/main/java/com/on/server/domain/comment/presentation/CommentController.java
+++ b/src/main/java/com/on/server/domain/comment/presentation/CommentController.java
@@ -8,6 +8,7 @@ import com.on.server.global.security.SecurityService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -34,7 +35,7 @@ public class CommentController {
     @GetMapping("/{postId}")
     public ResponseEntity<Page<CommentResponseDTO>> getAllCommentsAndRepliesByPostId(
             @PathVariable("postId") Long postId,
-            Pageable pageable
+            @ParameterObject Pageable pageable
     ) {
         Page<CommentResponseDTO> comments = commentService.getAllCommentsAndRepliesByPostId(postId, pageable);
         return ResponseEntity.ok(comments);
@@ -46,7 +47,7 @@ public class CommentController {
     @GetMapping("/{commentId}/reply")
     public ResponseEntity<Page<CommentResponseDTO>> getAllRepliesByCommentId(
             @PathVariable("commentId") Long commentId,
-            Pageable pageable
+            @ParameterObject Pageable pageable
     ) {
         Page<CommentResponseDTO> replies = commentService.getAllRepliesByCommentId(commentId, pageable);
         return ResponseEntity.ok(replies);

--- a/src/main/java/com/on/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/on/server/global/security/config/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
         corsConfig.addAllowedOrigin("http://localhost:3000");
         corsConfig.addAllowedOrigin("http://localhost:8080");
         corsConfig.addAllowedOrigin("https://on-boarding-abroad.vercel.app/");
+        corsConfig.addAllowedOrigin("https://on-refactoring-git-vercel-1425s-projects.vercel.app/");
         corsConfig.addAllowedMethod("*");
         corsConfig.addAllowedHeader("*");
         corsConfig.setAllowCredentials(true);

--- a/src/main/java/com/on/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/on/server/global/security/config/SecurityConfig.java
@@ -34,8 +34,7 @@ public class SecurityConfig {
 
         corsConfig.addAllowedOrigin("http://localhost:3000");
         corsConfig.addAllowedOrigin("http://localhost:8080");
-        corsConfig.addAllowedOrigin("https://on-3t2xzl2wq-1425s-projects.vercel.app");
-        corsConfig.addAllowedOrigin("https://on-xi.vercel.app");
+        corsConfig.addAllowedOrigin("https://on-boarding-abroad.vercel.app/");
         corsConfig.addAllowedMethod("*");
         corsConfig.addAllowedHeader("*");
         corsConfig.setAllowCredentials(true);


### PR DESCRIPTION
## 📝댓글 및 답글 API 리팩토링

> - ResponseDTO에 from 메서드 추가
> - WriterInfo 별도 클래스로 분리
> - UserDetails에서 User 객체를 가져오도록 수정
> - CommentRequestDTO에서 사용자id 제거
> - Response Entity 응답 상태코드 ok로 통일
> - GlobalExceptionHandler로 예외처리 변경
> - Comment 엔티티에서 childrenComment 필드 삭제
> - 댓글/답글 조회기능에 paging 추가