### PR TITLE
fix: 물품거래글을 도시 키워드로도 검색 가능하도록 수정

### DIFF
--- a/src/main/java/com/on/server/domain/marketPost/domain/repository/MarketPostRepository.java
+++ b/src/main/java/com/on/server/domain/marketPost/domain/repository/MarketPostRepository.java
@@ -31,6 +31,7 @@ public interface MarketPostRepository extends JpaRepository<MarketPost, Long> {
     // 검색: 국가와 물품에 대한 제목 또는 내용을 검색하는 메서드
     @Query("SELECT mp FROM MarketPost mp WHERE " +
             "mp.currentCountry LIKE %:keyword% OR " +
+            "mp.currentLocation LIKE %:keyword% OR " + // 도시로도 글이 검색되도록 추가
             "mp.title LIKE %:keyword% OR " +
             "mp.content LIKE %:keyword% " +
             "ORDER BY mp.createdAt DESC")


### PR DESCRIPTION
## 📝작업 내용 / 스크린샷

물품 거래글을 currentLocation으로도 검색할 수 있도록 쿼리문 수정