### PR TITLE
Feature: 게시글별 댓글 인덱스 응답 추가

### DIFF
--- a/src/main/java/com/on/server/domain/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/com/on/server/domain/comment/domain/repository/CommentRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
@@ -32,4 +33,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     // 특정 댓글에 답글이 몇 개인지 카운트
     int countByParentComment(Comment parentComment);
+
+    // 댓글 인덱스
+    @Query("SELECT COUNT(c) FROM Comment c WHERE c.post = :post AND c.parentComment IS NULL AND c.createdAt <= :createdAt")
+    long countByPostAndCreatedAtLessThanEqual(@Param("post") Post post, @Param("createdAt") LocalDateTime createdAt);
 }

--- a/src/main/java/com/on/server/domain/comment/dto/CommentResponseDTO.java
+++ b/src/main/java/com/on/server/domain/comment/dto/CommentResponseDTO.java
@@ -38,6 +38,9 @@ public class CommentResponseDTO {
     // 답글 개수
     private Integer replyCount;
 
+    // 댓글 인덱스
+    private Long commentIndex;
+
 
     public static CommentResponseDTO from(Comment comment, CommentRepository commentRepository) {
         boolean isReply = comment.getParentComment() != null;
@@ -51,6 +54,13 @@ public class CommentResponseDTO {
         }
 
         String nickname = comment.getIsAnonymous() ? "익명" + comment.getAnonymousIndex() : comment.getUser().getNickname();
+
+        // 댓글 인덱스 계산 (답글이 아닌 경우만)
+        Long commentIndex = isReply ? null :
+                commentRepository.countByPostAndCreatedAtLessThanEqual(
+                        comment.getPost(),
+                        comment.getCreatedAt()
+                ) - 1;
 
         WriterInfo writerInfo = WriterInfo.builder()
                 .id(comment.getUser().getId())
@@ -66,6 +76,7 @@ public class CommentResponseDTO {
                 .contents(comment.getContents())
                 .replyCount(isReply ? 0 : commentRepository.countByParentComment(comment))
              //   .replyCount(comment.getChildrenComment() != null ? comment.getChildrenComment().size() : 0)
+                .commentIndex(commentIndex) // 댓글 인덱스
                 .build();
     }
 


### PR DESCRIPTION
## 📝작업 내용 / 스크린샷

- 각 게시글 내에서 댓글의 순서를 식별할 수 있도록 댓글 작성 시 commentIndex를 Response에 추가

- 댓글이 작성된 시간을 기준으로 해당 게시글의 이전 댓글 수를 카운트하여 인덱스 생성