### PR TITLE
fix: 내 주변 동행글 국가명 조회 쿼리 수정 및 페이징

### DIFF
--- a/src/main/java/com/on/server/domain/companyPost/application/CompanyPostService.java
+++ b/src/main/java/com/on/server/domain/companyPost/application/CompanyPostService.java
@@ -15,6 +15,7 @@ import com.on.server.global.common.exceptions.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -136,7 +137,7 @@ public class CompanyPostService {
         String firstCountry = post.getTravelArea().get(0).split(" ")[0];
 
         // 국가와 일치하는 다른 게시글을 조회, 현재 게시글은 제외
-        List<CompanyPost> nearbyPosts = companyPostRepository.findTop5ByTravelAreaLike(firstCountry, companyPostId);
+        List<CompanyPost> nearbyPosts = companyPostRepository.findTop5ByTravelAreaLike(firstCountry, companyPostId, PageRequest.of(0, 5));
 
         return nearbyPosts.stream()
                 .map(CompanyPostResponseDTO::from)

--- a/src/main/java/com/on/server/domain/companyPost/application/CompanyPostService.java
+++ b/src/main/java/com/on/server/domain/companyPost/application/CompanyPostService.java
@@ -128,7 +128,7 @@ public class CompanyPostService {
     }
 
     // 내 주변 동행글 조회
-    public List<CompanyPostResponseDTO> getNearbyCompanyPostsByLikeTravelArea(Long companyPostId) {
+    public List<CompanyPostResponseDTO> getNearbyCompanyPostsByLikeTravelArea(Long companyPostId, User user) {
 
         // 여러 개의 travel area 중에서 첫 번째만 선택
         CompanyPostResponseDTO post = getCompanyPostById(companyPostId).get(0);
@@ -136,8 +136,8 @@ public class CompanyPostService {
         // 국가만 일치해도 조회되도록 국가 부분만 추출
         String firstCountry = post.getTravelArea().get(0).split(" ")[0];
 
-        // 국가와 일치하는 다른 게시글을 조회, 현재 게시글은 제외
-        List<CompanyPost> nearbyPosts = companyPostRepository.findTop5ByTravelAreaLike(firstCountry, companyPostId, PageRequest.of(0, 5));
+        // 국가와 일치하는 다른 게시글을 조회, 현재 사용자가 작성한 게시글은 제외
+        List<CompanyPost> nearbyPosts = companyPostRepository.findTop5ByTravelArea(firstCountry, user, PageRequest.of(0, 5));
 
         return nearbyPosts.stream()
                 .map(CompanyPostResponseDTO::from)

--- a/src/main/java/com/on/server/domain/companyPost/domain/repository/CompanyPostRepository.java
+++ b/src/main/java/com/on/server/domain/companyPost/domain/repository/CompanyPostRepository.java
@@ -48,8 +48,9 @@ public interface CompanyPostRepository extends JpaRepository<CompanyPost, Long> 
     @Query("SELECT c FROM CompanyPost c JOIN c.travelArea t WHERE t LIKE CONCAT('%', :country, '%') AND c.isRecruitCompleted = false AND c.user <> :user ORDER BY c.createdAt DESC")
     List<CompanyPost> findTop5ByTravelArea(@Param("country") String country, @Param("user") User user, Pageable pageable);
 
-    @Query("SELECT c FROM CompanyPost c JOIN c.travelArea t WHERE t LIKE CONCAT('%', :country, '%') AND c.isRecruitCompleted = false AND c.id <> :companyPostId ORDER BY c.createdAt DESC")
-    List<CompanyPost> findTop5ByTravelAreaLike(@Param("country") String country, @Param("companyPostId") Long companyPostId);
+    // 내 주변 동행글
+    @Query("SELECT c FROM CompanyPost c JOIN c.travelArea t WHERE t LIKE CONCAT(:country, ' %') AND c.isRecruitCompleted = false AND c.id <> :companyPostId ORDER BY c.createdAt DESC")
+    List<CompanyPost> findTop5ByTravelAreaLike(@Param("country") String country, @Param("companyPostId") Long companyPostId, Pageable pageable);
 
     // 최신순 정렬
     Page<CompanyPost> findAllByOrderByCreatedAtDesc(Pageable pageable);

--- a/src/main/java/com/on/server/domain/companyPost/domain/repository/CompanyPostRepository.java
+++ b/src/main/java/com/on/server/domain/companyPost/domain/repository/CompanyPostRepository.java
@@ -45,12 +45,8 @@ public interface CompanyPostRepository extends JpaRepository<CompanyPost, Long> 
     * @param country: 검색할 국가명
     * @param user: 현재 로그인한 사용자 (사용자가 작성한 글은 제외)
     */
-    @Query("SELECT c FROM CompanyPost c JOIN c.travelArea t WHERE t LIKE CONCAT('%', :country, '%') AND c.isRecruitCompleted = false AND c.user <> :user ORDER BY c.createdAt DESC")
+    @Query("SELECT c FROM CompanyPost c JOIN c.travelArea t WHERE t LIKE CONCAT(:country, ' %') AND c.isRecruitCompleted = false AND c.user <> :user ORDER BY c.createdAt DESC")
     List<CompanyPost> findTop5ByTravelArea(@Param("country") String country, @Param("user") User user, Pageable pageable);
-
-    // 내 주변 동행글
-    @Query("SELECT c FROM CompanyPost c JOIN c.travelArea t WHERE t LIKE CONCAT(:country, ' %') AND c.isRecruitCompleted = false AND c.id <> :companyPostId ORDER BY c.createdAt DESC")
-    List<CompanyPost> findTop5ByTravelAreaLike(@Param("country") String country, @Param("companyPostId") Long companyPostId, Pageable pageable);
 
     // 최신순 정렬
     Page<CompanyPost> findAllByOrderByCreatedAtDesc(Pageable pageable);

--- a/src/main/java/com/on/server/domain/companyPost/presentation/CompanyPostController.java
+++ b/src/main/java/com/on/server/domain/companyPost/presentation/CompanyPostController.java
@@ -115,8 +115,10 @@ public class CompanyPostController {
     @Operation(summary = "내 주변 동행글 조회")
     @PreAuthorize("@securityService.isNotTemporaryUser()")
     @GetMapping("/{companyPostId}/nearby")
-    public ResponseEntity<List<CompanyPostResponseDTO>> getNearbyCompanyPostsByLikeTravelArea(@PathVariable Long companyPostId) {
-        List<CompanyPostResponseDTO> nearbyPosts = companyPostService.getNearbyCompanyPostsByLikeTravelArea(companyPostId);
+    public ResponseEntity<List<CompanyPostResponseDTO>> getNearbyCompanyPostsByLikeTravelArea(@PathVariable Long companyPostId, @AuthenticationPrincipal UserDetails userDetails) {
+        User user = securityService.getUserByUserDetails(userDetails);
+
+        List<CompanyPostResponseDTO> nearbyPosts = companyPostService.getNearbyCompanyPostsByLikeTravelArea(companyPostId, user);
         return ResponseEntity.ok(nearbyPosts);
     }
 }


### PR DESCRIPTION
## 📝작업 내용 / 스크린샷

- 홈화면과 동행구하기글 상세보기에서 내 주변 동행글 조회시 국가명이 부분 일치 되어도 함께 조회되는 문제 ('인도' 검색시 '인도네시아'가 포함됨) 쿼리 수정

- 내 주변 동행글이 5개만 조회 되도록 페이징 추가

- 내가 쓴 글은 조회에서 제외되도록 수정

- 홈화면 내 주변 동행글 조회에서 사용하던 쿼리로 통일해서 사용