### PR TITLE
fix: 동행구하기글 조회시 작성시간을 한국시간으로 고정해서 표시

### DIFF
--- a/src/main/java/com/on/server/domain/companyPost/dto/CompanyPostResponseDTO.java
+++ b/src/main/java/com/on/server/domain/companyPost/dto/CompanyPostResponseDTO.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Period;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -100,7 +101,9 @@ public class CompanyPostResponseDTO {
                 .startDate(companyPost.getStartDate())
                 .endDate(companyPost.getEndDate())
                 .currentCountry(companyPost.getCurrentCountry())
-                .createdAt(companyPost.getCreatedAt())
+                .createdAt(companyPost.getCreatedAt().atZone(ZoneId.of("UTC"))
+                        .withZoneSameInstant(ZoneId.of("Asia/Seoul"))
+                        .toLocalDateTime())
                 .imageUrls(companyPost.getImages().stream()
                         .map(UuidFile::getFileUrl)
                         .collect(Collectors.toList()))  // 이미지 URL 리스트


### PR DESCRIPTION
## 📝작업 내용 / 스크린샷

ResponseDTO에서 UTC를 한국 시간으로 변환해서, 게시글 조회 시 작성 시간이 한국 시간으로 표시될 수 있도록 수정