### PR TITLE
Fix: 정보/자유게시글 조회 시 작성 시간을 한국시간으로 변환

### DIFF
--- a/src/main/java/com/on/server/domain/post/dto/PostResponseDTO.java
+++ b/src/main/java/com/on/server/domain/post/dto/PostResponseDTO.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -67,6 +68,11 @@ public class PostResponseDTO {
                 .userStatus(userStatus)
                 .build();
 
+        LocalDateTime createdAtInSeoul = post.getCreatedAt()
+                .atZone(ZoneId.of("UTC"))
+                .withZoneSameInstant(ZoneId.of("Asia/Seoul"))
+                .toLocalDateTime();
+
         return PostResponseDTO.builder()
                 .postId(post.getId())
                 .boardType(post.getBoard().getType())
@@ -75,7 +81,7 @@ public class PostResponseDTO {
                 .content(post.getContent())
                 .isAnonymous(post.getIsAnonymous())
                 .isAnonymousUniv(post.getIsAnonymousUniv())
-                .createdAt(post.getCreatedAt())
+                .createdAt(createdAtInSeoul)
                 .commentCount(includeCommentCount ? commentCount : 0)
                 .imageUrls(post.getImages().stream().map(UuidFile::getFileUrl).collect(Collectors.toList()))
                 .build();


### PR DESCRIPTION
## 📝작업 내용 / 스크린샷

> ResponseDTO에서 UTC를 한국 시간으로 변환해서 게시글 조회시 한국시간으로 표시되도록 수정
