### PR TITLE
fix: 동행구하기글 국가 필터링 쿼리 수정

### DIFF
--- a/src/main/java/com/on/server/domain/companyPost/application/CompanyPostService.java
+++ b/src/main/java/com/on/server/domain/companyPost/application/CompanyPostService.java
@@ -14,7 +14,6 @@ import com.on.server.global.common.exceptions.BadRequestException;
 import com.on.server.global.common.exceptions.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -36,18 +35,7 @@ public class CompanyPostService {
 
     // 필터링 기능 추가
     public Page<CompanyPostResponseDTO> getFilteredCompanyPosts(LocalDate startDate, LocalDate endDate, Gender gender, String country, Pageable pageable) {
-        Page<CompanyPost> posts = companyPostRepository.findFilteredCompanyPostsWithoutCountry(startDate, endDate, gender, pageable);
-
-        if (country != null && !country.isEmpty()) {
-            posts = posts.stream()
-                    .filter(post -> post.getTravelArea().stream()
-                            .anyMatch(area -> {
-                                String firstWord = area.split(" ")[0];  // travelArea의 첫 번째 단어 추출
-                                return firstWord.equalsIgnoreCase(country);
-                            }))
-                    .collect(Collectors.collectingAndThen(Collectors.toList(), list -> new PageImpl<>(list, pageable, list.size())));
-        }
-
+        Page<CompanyPost> posts = companyPostRepository.findFilteredCompanyPosts(startDate, endDate, gender, country, pageable);
         return posts.map(CompanyPostResponseDTO::from);
     }
 

--- a/src/main/java/com/on/server/domain/companyPost/domain/repository/CompanyPostRepository.java
+++ b/src/main/java/com/on/server/domain/companyPost/domain/repository/CompanyPostRepository.java
@@ -19,14 +19,17 @@ import java.util.List;
 public interface CompanyPostRepository extends JpaRepository<CompanyPost, Long> {
 
     // 필터링을 위한 쿼리
-    @Query("SELECT cp FROM CompanyPost cp WHERE (:startDate IS NULL OR cp.startDate >= :startDate) " +
+    @Query("SELECT DISTINCT cp FROM CompanyPost cp JOIN cp.travelArea ta WHERE " +
+            "(:startDate IS NULL OR cp.startDate >= :startDate) " +
             "AND (:endDate IS NULL OR cp.endDate <= :endDate) " +
             "AND (:gender IS NULL OR cp.user.gender = :gender) " +
+            "AND (:country IS NULL OR SUBSTRING(ta, 1, LOCATE(' ', ta) - 1) = :country) " +
             "ORDER BY cp.createdAt DESC")
-    Page<CompanyPost> findFilteredCompanyPostsWithoutCountry(
+    Page<CompanyPost> findFilteredCompanyPosts(
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate,
             @Param("gender") Gender gender,
+            @Param("country") String country,
             Pageable pageable);
 
     // 최신 4개의 글을 최신순으로 가져오기


### PR DESCRIPTION
## 📝작업 내용 / 스크린샷

`CompanyPostService`의 `getFilteredCompanyPosts` 메서드에서 처리하던 국가 필터링을 repository에서 처리하도록 수정
